### PR TITLE
changes that allow us to not have state cleared when button pushed

### DIFF
--- a/scripts/Governors.js
+++ b/scripts/Governors.js
@@ -92,6 +92,7 @@ export const makeMineralList = () => {
         }
         }
         
+
         return html
     
 }

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -99,7 +99,7 @@ export const addMineralOrder = () => {
     database.mineralOrders.push(newOrder)
  
     // Reset the temporary state for user choices
-    database.transientState = {}
+   // database.transientState = {}
  
     // Broadcast a notification that permanent state has changed
     document.dispatchEvent(new CustomEvent("stateChanged"))


### PR DESCRIPTION
# Description

This fixes the problem where the colony mineral supplies would disappear between orders and would not reappear until a governor was selected.

We removed database.transientState = {} (which was resetting transient state) from the addMineralOrder function.
